### PR TITLE
monitoring_group_type 별 알림을 줄 수 있는 옵션 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.github.scouter-project</groupId>
     <artifactId>scouter-plugin-server-alert-slack</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -94,6 +94,15 @@
 
     <build>
         <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/src/main/java/scouter/plugin/server/alert/slack/MonitoringGroupConfigure.java
+++ b/src/main/java/scouter/plugin/server/alert/slack/MonitoringGroupConfigure.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2016 Scouter Project.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); 
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. 
+ *  
+ *  @author Gookeun Lim
+ */
+package scouter.plugin.server.alert.slack;
+
+import scouter.server.Configure;
+
+/**
+ * <p>a class that helps to find a property value which matches to a specific monitoring_group_type key(aks obj_type).
+ *  * You can defined a montioring_group_type values like below</p>
+ * 
+ * {objType}.{remain value}ext_plugin_slack_...
+ *  
+ * ex) 
+ *   ext_plugin_slack_channel=general_monitoring       
+ *   order_jvm.ext_plugin_slack_channel=order_monitoring
+ *   stock_jvm.ext_plugin_slack_channel=stock_monitoring
+ * 
+ * @author Gookeun Lim (passion.lim@gmail.com) on 2018.07.24
+ *
+ */
+public class MonitoringGroupConfigure {
+	private Configure conf;
+
+	public MonitoringGroupConfigure(Configure config) {
+		this.conf = config;
+	}
+
+	public String getValue(String key, String objType) {
+		return this.getValue(key, objType, null);
+	}
+
+	public String getGroupKey(String originalKey, String objType) {
+		if (originalKey == null) {
+			return originalKey;
+		}
+		
+		return objType+"."+originalKey;
+	}
+
+	public String getValue(String key, String objType, String defaultValue) {
+		String groupKey = getGroupKey(key, objType);
+		String value = conf.getValue(groupKey);
+		if (value != null && value.trim().length() > 0) {
+			return value;
+		}
+		// default key value
+		value = conf.getValue(key);
+		return value != null? value : defaultValue;
+	}
+
+	public Boolean getBoolean(String key, final String objType, Boolean defaultValue) {
+		String groupKey = getGroupKey(key, objType);
+		Boolean value = toBoolean(conf.getValue(groupKey));
+		if (value != null) {
+			return value;
+		}
+		// default key value
+		value = toBoolean(conf.getValue(key));
+		return value != null? value : defaultValue;
+	}
+	
+	public int getInt(String key, String objType, int defaultValue) {
+		String groupKey = getGroupKey(key, objType);
+		Integer value = toInteger(conf.getValue(groupKey));
+		if (value != null) {
+			return value;
+		}
+		// default key value
+		value = toInteger(conf.getValue(key));
+		return value != null ? value : defaultValue;
+	}
+
+	public long getLong(String key, String objType, long defaultValue) {
+		String groupKey = getGroupKey(key, objType);
+		Long value = toLong(conf.getValue(groupKey));
+		if (value != null) {
+			return value;
+		}
+		// default key value
+		value = toLong(conf.getValue(key));
+		return value != null ? value : defaultValue;
+	}
+
+	
+	private Long toLong(String value) {
+		try {
+			if (value != null) {
+				return Long.parseLong(value);
+			}
+		} catch (Exception e) {
+			// ignore exception
+		}
+		return null;
+	}
+
+	private Integer toInteger(String value) {
+		try {
+			if (value != null) {
+				return Integer.parseInt(value);
+			}
+		} catch (Exception e) {
+			// ignore exception
+		}
+		return null;
+	}
+
+	private Boolean toBoolean(String value) {
+		try {
+			if (value != null) {
+				return Boolean.parseBoolean(value);
+			}
+		} catch (Exception e) {
+			// ignore exception
+		}
+		return null;
+	}
+}

--- a/src/test/java/scouter/plugin/server/alert/slack/MonitoringGroupConfigureTest.java
+++ b/src/test/java/scouter/plugin/server/alert/slack/MonitoringGroupConfigureTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2016 Scouter Project.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); 
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License. 
+ *  
+ *  @author Gookeun Lim
+ */
+package scouter.plugin.server.alert.slack;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import scouter.server.Configure;
+
+/**
+ * Unit Test For MonitoringGroupConfigure
+ *  
+ * @author Gookeun Lim (passion.lim@gmail.com) on 2018.07.24 
+ */
+public class MonitoringGroupConfigureTest {
+	
+	MonitoringGroupConfigure sut;
+
+	@Test
+	public void test_getValue() {
+		String objType = "order_jvm";
+		Configure conf = mock(Configure.class);
+		sut = new MonitoringGroupConfigure(conf);
+		
+		// default value
+		assertEquals("http://webhook.example.com/default", sut.getValue("ext_plugin_slack_webhook_url", objType, "http://webhook.example.com/default"));
+		
+		// conf value
+		when(conf.getValue("ext_plugin_slack_webhook_url")).thenReturn("http://webhook.example.com/tomcat");
+		assertEquals("http://webhook.example.com/tomcat", sut.getValue("ext_plugin_slack_webhook_url", objType));
+		
+		// appended value with groupKey
+		when(conf.getValue(objType+".ext_plugin_slack_webhook_url")).thenReturn("http://webhook.example.com/order_jvm");
+		assertEquals("http://webhook.example.com/order_jvm", sut.getValue("ext_plugin_slack_webhook_url", objType));
+	}
+	
+	@Test
+	public void test_getIntegerValue() {
+		String objType = "order_jvm";
+		Configure conf = mock(Configure.class);
+		sut = new MonitoringGroupConfigure(conf);
+		
+		// default value
+		assertEquals(1000, sut.getInt("ext_plugin_slack_elapsed_time_threshold", objType, 1000));
+		
+		// conf value
+		when(conf.getValue("ext_plugin_slack_elapsed_time_threshold")).thenReturn("2000");
+		assertEquals(2000, sut.getInt("ext_plugin_slack_elapsed_time_threshold", objType, 1000));
+		
+		// appended value with groupKey
+		when(conf.getValue(objType+".ext_plugin_slack_elapsed_time_threshold")).thenReturn("3000");
+		assertEquals(3000, sut.getInt("ext_plugin_slack_elapsed_time_threshold", objType, 1000));
+		
+	}
+
+	@Test
+	public void test_getLongValue() {
+		String objType = "order_jvm";
+		Configure conf = mock(Configure.class);
+		sut = new MonitoringGroupConfigure(conf);
+		
+		// default value
+		assertEquals(1000000000000L, sut.getLong("ext_plugin_slack_elapsed_time_threshold", objType, 1000000000000L));
+		
+		// conf value
+		when(conf.getValue("ext_plugin_slack_elapsed_time_threshold")).thenReturn("2000000000000");
+		assertEquals(2000000000000L, sut.getLong("ext_plugin_slack_elapsed_time_threshold", objType, 1000000000000L));
+		
+		// appended value with groupKey
+		when(conf.getValue(objType+".ext_plugin_slack_elapsed_time_threshold")).thenReturn("3000000000000");
+		assertEquals(3000000000000L, sut.getLong("ext_plugin_slack_elapsed_time_threshold", objType, 1000000000000L));
+	}
+
+	@Test
+	public void test_getBooleanValue() {
+		String objType = "order_jvm";
+		Configure conf = mock(Configure.class);
+		sut = new MonitoringGroupConfigure(conf);
+		
+		// default value
+		assertEquals(Boolean.TRUE, sut.getBoolean("ext_plugin_slack_elapsed_time_threshold", objType, Boolean.TRUE));
+		
+		// conf value
+		when(conf.getValue("ext_plugin_slack_elapsed_time_threshold")).thenReturn("false");
+		assertEquals(Boolean.FALSE, sut.getBoolean("ext_plugin_slack_elapsed_time_threshold", objType, Boolean.TRUE));
+		
+		// appended value with groupKey
+		when(conf.getValue(objType+".ext_plugin_slack_elapsed_time_threshold")).thenReturn("true");
+		assertEquals(Boolean.TRUE, sut.getBoolean("ext_plugin_slack_elapsed_time_threshold", objType, Boolean.FALSE));
+	}
+	
+}


### PR DESCRIPTION
https://github.com/scouter-project/scouter/issues/482

위 질문의 Comments 에 대한 Pull Request 입니다.

현재 Slack Plugin 1.0 기본 설정은 하나의 Collector Server 를 위한 것으로 시스템별 Slack 채널을 선택할 수 있는 방법이 없습니다. 여러 조건에 따라 알림을 발생하려면 Collector 서버를 분리해야 합니다. 

해당 변경사항은 Scouter Collector Server 에서 monitoring_group_type(구 obj_type) 별로 Slack 알림 설정을 지정할 수 있는 기능 변경 사항입니다.

아래 설정은 기본적으로는 Slack Alarm 이 꺼져있지만 monitoring_group_type(구 objType)이 order_tomcat 인 경우 알림이 발생하도록 할 수 있습니다.
```
# External Interface (Slack)
ext_plugin_slack_send_alert=false
# 주문 tomcat 시스템 알림 켬
order_tomcat.ext_plugin_slack_send_alert=true

# 주문 tomcat 시스템 알림 채널 변경
order_tomcat.ext_plugin_slack_channel=scouter_order

```

일 변경이 반영되면 하나의 Collector 서버에서 다양한 Slack 알림/ICON/Bot이름 등을 수정해 보낼 수 있습니다.